### PR TITLE
feat(layout): add metadata for SEO and social sharing

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,6 +24,24 @@ export const metadata: Metadata = {
   icons: {
     icon: '/logo.png',
   },
+  keywords: ['記帳', '理財', '支出管理', '收入記錄', '快樂記帳'],
+  authors: [{ name: 'Briony', url: 'https://coin-tracker-eosin.vercel.app/' }],
+  openGraph: {
+    title: '快樂記帳',
+    description: '輕鬆掌握生活收支，打造專屬你的財務自由。',
+    url: 'https://coin-tracker-eosin.vercel.app/',
+    siteName: '快樂記帳',
+    images: [
+      {
+        url: 'https://coin-tracker-eosin.vercel.app/logo.png',
+        width: 1200,
+        height: 630,
+        alt: '快樂記帳預覽圖',
+      },
+    ],
+    locale: 'zh_TW',
+    type: 'website',
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Feat
- 優化 SEO: 修改 metadata、增加分享 Line 時縮圖功能
- Before
<img width="284" alt="截圖 2025-06-15 下午6 55 07" src="https://github.com/user-attachments/assets/3004a130-066b-4bb0-a09c-dd4aeda5b390" />

- After
<img width="276" alt="截圖 2025-06-15 下午6 54 43" src="https://github.com/user-attachments/assets/2e816dfb-97cf-45b8-a8d8-5be759a03fa3" />
